### PR TITLE
Add -f flag to rm so that the script doesn't exit

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -1,7 +1,7 @@
 [ -d repos/ ] || ./setup.sh
 [ -f .hmd-setup ] || ./hmd-setup.sh
 [ -f /tmp/telescope.log ] && rm /tmp/telescope.log
-[ -d logs/ ] && rm logs/*
+[ -d logs/ ] && rm -f logs/*
 
 #? strip ANSI escape sequences from stdin
 function strip-ansi() {


### PR DESCRIPTION
Hi, if `logs/` is empty, the `util.sh` script exits, causing any scripts that source it to fail silently. e.g.:

```sh
❯ ./xr-terminal.sh
rm: cannot remove 'logs/*': No such file or directory
```

Adding the `-f` option tells the `rm` command to force the removal of files without prompting for confirmation, even if the files do not exist.